### PR TITLE
Advanced filters aligned with tablecn (filterRows, Filter list/menu demo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ Relevant options:
 - `scroll`
 - `shallow`
 
+For advanced filters (multi-rule, AND/OR, operators), see [docs/ADVANCED_FILTERS.md](./docs/ADVANCED_FILTERS.md). The demo toggles **Filter list** vs **Filter menu** like tablecn’s `filterFlag`.
+
 ## Cell Variants
 
 The data grid supports multiple cell types:

--- a/docs/ADVANCED_FILTERS.md
+++ b/docs/ADVANCED_FILTERS.md
@@ -1,0 +1,66 @@
+# Advanced filters (tablecn parity)
+
+This document maps [sadmann7/tablecn](https://github.com/sadmann7/tablecn) filtering patterns to **svelte-tablecn**.
+
+## Three filter modes
+
+| Mode | tablecn | svelte-tablecn | URL state |
+|------|---------|----------------|-----------|
+| **Basic toolbar** | `DataTableToolbar` + per-column `nuqs` params | `DataTableToolbar` + column keys in query string | `?status=Active&department=Sales` |
+| **Advanced list** | `filterFlag=advancedFilters` + `DataTableFilterList` | `advancedFilterUi="advancedFilters"` | `?filters=…&joinOperator=and` |
+| **Command menu** | `filterFlag=commandFilters` + `DataTableFilterMenu` | `advancedFilterUi="commandFilters"` | same as advanced list |
+
+Enable advanced URL sync with `enableAdvancedFilter: true` on `useDataTable`.
+
+## Client vs server filtering
+
+### Client-side (demo)
+
+When `enableAdvancedFilter` is true and `manualFiltering` is false (default in the showcase), `useDataTable` applies [`filterRows`](../src/lib/filter-rows.ts) before rows reach TanStack Table. That supports:
+
+- Multiple rules on the same column (`filterId`)
+- Full operator set (`contains`, `between`, `isAnyOf`, …)
+- `joinOperator`: `and` | `or`
+
+### Server-side (production, like tablecn)
+
+tablecn always uses `manualPagination`, `manualSorting`, and `manualFiltering: true`. The server reads serialized filters from the URL and builds SQL with [`filter-columns.ts`](https://github.com/sadmann7/tablecn/blob/main/src/lib/filter-columns.ts).
+
+In svelte-tablecn:
+
+1. Set `manualFiltering: true` (and usually `manualPagination` / `manualSorting`).
+2. Pass only the current page of rows into `data`.
+3. On the server, parse `filters` + `joinOperator` from the query string (see `getFiltersStateParser`).
+4. Map UI operators to SQL with [`map-sql-filter-operators.ts`](../src/lib/map-sql-filter-operators.ts), then implement Drizzle conditions (port `filter-columns.ts` or equivalent).
+
+Example operator mapping:
+
+| UI (client) | SQL (tablecn / Drizzle) |
+|-------------|-------------------------|
+| `contains` | `iLike` |
+| `isAnyOf` | `inArray` |
+| `between` | `isBetween` |
+| `lessThan` | `lt` |
+
+## Feature flag pattern (tablecn)
+
+tablecn stores `filterFlag` in the URL and derives:
+
+```ts
+enableAdvancedFilter =
+  filterFlag === 'advancedFilters' || filterFlag === 'commandFilters';
+```
+
+The demo on the home page mirrors this with **Filter list** / **Filter menu** toggles when **Advanced Table** is selected.
+
+## Related files
+
+| Purpose | Path |
+|---------|------|
+| Table hook + URL sync | `src/lib/hooks/use-data-table.svelte.ts` |
+| In-memory filter engine | `src/lib/filter-rows.ts` |
+| SQL operator mapping | `src/lib/map-sql-filter-operators.ts` |
+| Filter list UI | `src/lib/components/data-table/data-table-filter-list.svelte` |
+| Filter menu UI | `src/lib/components/data-table/data-table-filter-menu.svelte` |
+| Grid filters (10k rows) | `src/lib/components/data-grid/data-grid-filter-menu.svelte` |
+| Demo | `src/routes/data-table-showcase.svelte` |

--- a/src/lib/filter-rows.ts
+++ b/src/lib/filter-rows.ts
@@ -1,0 +1,73 @@
+// Client-side row filtering for advanced data-table filters.
+// Mirrors the role of tablecn's filter-columns.ts (Drizzle/SQL) for in-memory data.
+
+import type { Row } from '@tanstack/table-core';
+import { getFilterFn } from '$lib/data-grid-filters.js';
+import type { FilterValue } from '$lib/types/data-grid.js';
+import type { ExtendedColumnFilter, JoinOperator } from '$lib/types/data-table.js';
+import { getValidFilters } from '$lib/types/data-table.js';
+
+function toFilterValue<TData>(filter: ExtendedColumnFilter<TData>): FilterValue {
+	const values = Array.isArray(filter.value) ? filter.value : [filter.value];
+
+	if (filter.operator === 'between' && values.length >= 2) {
+		return {
+			operator: filter.operator,
+			value: values[0],
+			value2: values[1]
+		};
+	}
+
+	if (filter.operator === 'isAnyOf' || filter.operator === 'isNoneOf') {
+		return {
+			operator: filter.operator,
+			value: values
+		};
+	}
+
+	return {
+		operator: filter.operator,
+		value: values[0]
+	};
+}
+
+function createRowAdapter<TData>(
+	row: TData,
+	getCellValue: (row: TData, columnId: string) => unknown
+): Pick<Row<TData>, 'getValue'> {
+	return {
+		getValue: <TValue>(columnId: string) => getCellValue(row, columnId) as TValue
+	};
+}
+
+function matchesFilter<TData>(
+	row: TData,
+	filter: ExtendedColumnFilter<TData>,
+	getCellValue: (row: TData, columnId: string) => unknown
+): boolean {
+	const rowAdapter = createRowAdapter(row, getCellValue);
+	const filterFn = getFilterFn<TData>();
+	return filterFn(rowAdapter as Row<TData>, filter.id, toFilterValue(filter), () => {});
+}
+
+/**
+ * Filters rows using advanced column filters and a join operator (and/or).
+ * Use for client-side demos or as a reference when building server-side SQL filters.
+ */
+export function filterRows<TData>(
+	rows: TData[],
+	filters: ExtendedColumnFilter<TData>[],
+	joinOperator: JoinOperator,
+	getCellValue: (row: TData, columnId: string) => unknown = (row, columnId) =>
+		(row as Record<string, unknown>)[columnId]
+): TData[] {
+	const validFilters = getValidFilters(filters);
+	if (validFilters.length === 0) {
+		return rows;
+	}
+
+	return rows.filter((row) => {
+		const results = validFilters.map((filter) => matchesFilter(row, filter, getCellValue));
+		return joinOperator === 'or' ? results.some(Boolean) : results.every(Boolean);
+	});
+}

--- a/src/lib/hooks/use-data-table.svelte.ts
+++ b/src/lib/hooks/use-data-table.svelte.ts
@@ -18,8 +18,10 @@ import {
 import { DATA_TABLE_DEFAULTS, DEFAULT_DATA_TABLE_QUERY_KEYS } from '$lib/config/data-table.js';
 import { getFiltersStateParser, getSortingStateParser } from '$lib/parsers.js';
 import { createSvelteTable } from '$lib/table';
+import { filterRows } from '$lib/filter-rows.js';
 import {
 	getDefaultFilterOperator,
+	getValidFilters,
 	type ExtendedColumnFilter,
 	type ExtendedColumnSort,
 	type FilterVariant,
@@ -402,9 +404,25 @@ export function useDataTable<TData>(
 		void syncQueryState(delay);
 	});
 
+	const useClientAdvancedFiltering = enableAdvancedFilter && !manualFiltering;
+
 	const table = createSvelteTable<TData>({
 		get data() {
-			return getData();
+			const rawData = getData();
+
+			if (!useClientAdvancedFiltering) {
+				return rawData;
+			}
+
+			const advancedFilters = getValidFilters(
+				extractAdvancedFilters(columnFilters, getColumnVariant)
+			);
+
+			if (advancedFilters.length === 0) {
+				return rawData;
+			}
+
+			return filterRows(rawData, advancedFilters, joinOperator);
 		},
 		columns,
 		...(getRowId ? { getRowId } : {}),
@@ -447,7 +465,7 @@ export function useDataTable<TData>(
 		getFacetedMinMaxValues: getFacetedMinMaxValues(),
 		manualPagination,
 		manualSorting,
-		manualFiltering,
+		manualFiltering: useClientAdvancedFiltering ? true : manualFiltering,
 		meta: {
 			queryKeys: resolvedQueryKeys,
 			get joinOperator() {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -255,3 +255,9 @@ export {
 } from './hooks/use-badge-overflow.svelte.js';
 export { useDebouncedCallback, type DebouncedCallback } from './hooks/use-debounced-callback';
 export { useCallbackRef } from './hooks/use-callback-ref';
+export { filterRows } from './filter-rows.js';
+export {
+	toSqlFilterOperator,
+	fromSqlFilterOperator,
+	type SqlFilterOperator
+} from './map-sql-filter-operators.js';

--- a/src/lib/map-sql-filter-operators.ts
+++ b/src/lib/map-sql-filter-operators.ts
@@ -1,0 +1,69 @@
+// Maps between UI filter operators (client) and tablecn SQL operators (Drizzle).
+// See: https://github.com/sadmann7/tablecn/blob/main/src/lib/filter-columns.ts
+
+import type { FilterOperator } from '$lib/types/data-grid.js';
+
+/** Operators used by tablecn / Drizzle filter-columns.ts */
+export type SqlFilterOperator =
+	| 'iLike'
+	| 'notILike'
+	| 'eq'
+	| 'ne'
+	| 'inArray'
+	| 'notInArray'
+	| 'lt'
+	| 'lte'
+	| 'gt'
+	| 'gte'
+	| 'isBetween'
+	| 'isRelativeToToday'
+	| 'isEmpty'
+	| 'isNotEmpty';
+
+const UI_TO_SQL: Partial<Record<FilterOperator, SqlFilterOperator>> = {
+	contains: 'iLike',
+	notContains: 'notILike',
+	equals: 'eq',
+	notEquals: 'ne',
+	is: 'eq',
+	isNot: 'ne',
+	isAnyOf: 'inArray',
+	isNoneOf: 'notInArray',
+	lessThan: 'lt',
+	lessThanOrEqual: 'lte',
+	greaterThan: 'gt',
+	greaterThanOrEqual: 'gte',
+	before: 'lt',
+	after: 'gt',
+	onOrBefore: 'lte',
+	onOrAfter: 'gte',
+	between: 'isBetween',
+	isEmpty: 'isEmpty',
+	isNotEmpty: 'isNotEmpty',
+	isTrue: 'eq',
+	isFalse: 'ne'
+};
+
+const SQL_TO_UI: Partial<Record<SqlFilterOperator, FilterOperator>> = {
+	iLike: 'contains',
+	notILike: 'notContains',
+	eq: 'equals',
+	ne: 'notEquals',
+	inArray: 'isAnyOf',
+	notInArray: 'isNoneOf',
+	lt: 'lessThan',
+	lte: 'lessThanOrEqual',
+	gt: 'greaterThan',
+	gte: 'greaterThanOrEqual',
+	isBetween: 'between',
+	isEmpty: 'isEmpty',
+	isNotEmpty: 'isNotEmpty'
+};
+
+export function toSqlFilterOperator(operator: FilterOperator): SqlFilterOperator | undefined {
+	return UI_TO_SQL[operator];
+}
+
+export function fromSqlFilterOperator(operator: SqlFilterOperator): FilterOperator | undefined {
+	return SQL_TO_UI[operator];
+}

--- a/src/lib/types/data-table.ts
+++ b/src/lib/types/data-table.ts
@@ -257,8 +257,13 @@ export function getValidFilters<TData>(
 	filters: ExtendedColumnFilter<TData>[]
 ): ExtendedColumnFilter<TData>[] {
 	return filters.filter((filter) => {
-		// Empty operators don't need a value
-		if (filter.operator === 'isEmpty' || filter.operator === 'isNotEmpty') {
+		// Empty / boolean operators don't need a value
+		if (
+			filter.operator === 'isEmpty' ||
+			filter.operator === 'isNotEmpty' ||
+			filter.operator === 'isTrue' ||
+			filter.operator === 'isFalse'
+		) {
 			return true;
 		}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,6 +24,7 @@
 
 	type DemoMode = 'grid' | 'table';
 	type TableMode = 'basic' | 'advanced';
+	type AdvancedFilterUi = 'advancedFilters' | 'commandFilters';
 
 	interface Person {
 		id: string;
@@ -147,6 +148,7 @@
 	let data = $state<Person[]>(initialData);
 	let demoMode = $state<DemoMode>('grid');
 	let tableMode = $state<TableMode>('basic');
+	let advancedFilterUi = $state<AdvancedFilterUi>('commandFilters');
 	let showTableSkeleton = $state(false);
 
 	const { trackCellsUpdate, trackRowsAdd, trackRowsDelete } = useDataGridUndoRedo({
@@ -508,6 +510,23 @@
 				>
 					Advanced Table
 				</Button>
+				{#if tableMode === 'advanced'}
+					<span class="mx-1 text-muted-foreground">|</span>
+					<Button
+						variant={advancedFilterUi === 'advancedFilters' ? 'default' : 'outline'}
+						size="sm"
+						onclick={() => (advancedFilterUi = 'advancedFilters')}
+					>
+						Filter list
+					</Button>
+					<Button
+						variant={advancedFilterUi === 'commandFilters' ? 'default' : 'outline'}
+						size="sm"
+						onclick={() => (advancedFilterUi = 'commandFilters')}
+					>
+						Filter menu
+					</Button>
+				{/if}
 			</div>
 			<Button variant="outline" size="sm" onclick={() => (showTableSkeleton = !showTableSkeleton)}>
 				{showTableSkeleton ? 'Show Live Table' : 'Show Skeleton'}
@@ -521,8 +540,15 @@
 				rowCount={10}
 			/>
 		{:else}
-			{#key tableMode}
-				<DataTableShowcase mode={tableMode} rows={tableRows} {departments} {statuses} {skills} />
+			{#key `${tableMode}-${advancedFilterUi}`}
+				<DataTableShowcase
+					mode={tableMode}
+					{advancedFilterUi}
+					rows={tableRows}
+					{departments}
+					{statuses}
+					{skills}
+				/>
 			{/key}
 		{/if}
 	{/if}

--- a/src/routes/data-table-showcase.svelte
+++ b/src/routes/data-table-showcase.svelte
@@ -4,6 +4,7 @@
 		DataTable,
 		DataTableAdvancedToolbar,
 		DataTableColumnHeader,
+		DataTableFilterList,
 		DataTableFilterMenu,
 		DataTableSortList,
 		DataTableToolbar,
@@ -12,6 +13,8 @@
 	} from '$lib';
 
 	type DemoMode = 'basic' | 'advanced';
+	/** Matches tablecn filterFlag: advancedFilters (list) vs commandFilters (menu) */
+	type AdvancedFilterUi = 'advancedFilters' | 'commandFilters';
 
 	interface Person {
 		id: string;
@@ -27,13 +30,21 @@
 
 	interface Props {
 		mode: DemoMode;
+		advancedFilterUi?: AdvancedFilterUi;
 		rows: Person[];
 		departments: readonly string[];
 		statuses: readonly string[];
 		skills: readonly string[];
 	}
 
-	let { mode, rows, departments, statuses, skills }: Props = $props();
+	let {
+		mode,
+		advancedFilterUi = 'commandFilters',
+		rows,
+		departments,
+		statuses,
+		skills
+	}: Props = $props();
 
 	const currencyFormatter = new Intl.NumberFormat(undefined, {
 		style: 'currency',
@@ -234,8 +245,10 @@
 
 	const description =
 		mode === 'advanced'
-			? 'Advanced mode showcases sort lists, compact filter menus, and URL-synced state. It is best suited to server-side filtering flows.'
-			: 'Basic mode showcases client-side sorting, filtering, pagination, view options, sliders, and date filters.';
+			? advancedFilterUi === 'advancedFilters'
+				? 'Advanced list UI (tablecn advancedFilters): multi-rule filters with AND/OR, drag reorder, and URL-synced filters + joinOperator.'
+				: 'Command filter menu (tablecn commandFilters): compact popover filters with operators, synced to the URL.'
+			: 'Basic mode showcases per-column toolbar filters (tablecn default toolbar), client-side sort/filter, and faceted controls.';
 
 	const { table } = useDataTable({
 		data: () => rows,
@@ -270,8 +283,12 @@
 			{#snippet children()}
 				<DataTableAdvancedToolbar {table}>
 					{#snippet children()}
-						<DataTableSortList {table} />
-						<DataTableFilterMenu {table} />
+						<DataTableSortList {table} align="start" />
+						{#if advancedFilterUi === 'advancedFilters'}
+							<DataTableFilterList {table} align="start" />
+						{:else}
+							<DataTableFilterMenu {table} align="start" />
+						{/if}
 					{/snippet}
 				</DataTableAdvancedToolbar>
 			{/snippet}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ports key [tablecn](https://github.com/sadmann7/tablecn) advanced-filter patterns into svelte-tablecn so the demo and library match how the React reference works.

## Changes

- **`filterRows`** — Client-side engine for `ExtendedColumnFilter[]` + `joinOperator` (and/or), mirroring the role of tablecn's Drizzle `filter-columns.ts` for in-memory data.
- **`useDataTable`** — When `enableAdvancedFilter` is true and `manualFiltering` is false, rows are pre-filtered with `filterRows` so multi-rule filters and operators work correctly (TanStack's per-column filter model cannot express multiple rules on one column).
- **`map-sql-filter-operators`** — Maps UI operators (`contains`, `isAnyOf`, …) to tablecn SQL operators (`iLike`, `inArray`, …) for server implementations.
- **Demo** — Advanced table mode can switch **Filter list** vs **Filter menu** (tablecn `filterFlag`: `advancedFilters` / `commandFilters`).
- **Docs** — [docs/ADVANCED_FILTERS.md](docs/ADVANCED_FILTERS.md) explains basic vs advanced modes, client vs server filtering, and related files.

## How to try

1. Open the demo → **Data Table Demo** → **Advanced Table**
2. Toggle **Filter list** or **Filter menu**
3. Add filters with operators; URL syncs `filters` + `joinOperator`

## Server-side follow-up

For production (like tablecn tasks table), set `manualFiltering: true` and apply filters in your API using the SQL operator map + a Drizzle `filter-columns` port.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-557a98a9-1501-4ea3-a248-6a0c4b6f7149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-557a98a9-1501-4ea3-a248-6a0c4b6f7149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

