### PR TITLE
fix: infinite loop when changing advanced status filter

### DIFF
--- a/src/lib/components/data-table/data-table-filter-list.svelte
+++ b/src/lib/components/data-table/data-table-filter-list.svelte
@@ -55,31 +55,23 @@
 		table: Table<TData>;
 		disabled?: boolean;
 		align?: 'start' | 'center' | 'end';
-		joinOperator?: JoinOperator;
 		class?: string;
 	}
 
-	let {
-		table,
-		disabled = false,
-		align = 'start',
-		joinOperator = $bindable<JoinOperator>('and'),
-		class: className
-	}: Props = $props();
+	let { table, disabled = false, align = 'start', class: className }: Props = $props();
 
 	let open = $state(false);
 	const columnFilters = $derived(table.getState().columnFilters as FilterItem[]);
+	const columnFiltersSnapshot = $derived(JSON.stringify(columnFilters));
+	const joinOperator = $derived(table.options.meta?.joinOperator ?? 'and');
 	let filterItems = $state<FilterItem[]>([]);
+	let filterItemsSnapshot = $state('[]');
 
 	$effect(() => {
-		filterItems = [...columnFilters];
-	});
-
-	$effect(() => {
-		const metaJoinOperator = table.options.meta?.joinOperator;
-		if (metaJoinOperator && metaJoinOperator !== joinOperator) {
-			joinOperator = metaJoinOperator;
-		}
+		const snapshot = columnFiltersSnapshot;
+		if (snapshot === filterItemsSnapshot) return;
+		filterItemsSnapshot = snapshot;
+		filterItems = JSON.parse(snapshot) as FilterItem[];
 	});
 
 	const columns = $derived.by((): AvailableColumn[] => {
@@ -183,7 +175,6 @@
 	}
 
 	function onJoinOperatorChange(value: string) {
-		joinOperator = value as JoinOperator;
 		table.options.meta?.setJoinOperator?.(value as JoinOperator);
 	}
 

--- a/src/lib/components/ui/data-table/data-table.svelte.ts
+++ b/src/lib/components/ui/data-table/data-table.svelte.ts
@@ -77,10 +77,15 @@ export function createSvelteTable<TData extends RowData>(
 	});
 
 	function wrapOnChange<Updater>(
-		handler: ((updater: Updater) => void) | undefined
+		handler: ((updater: Updater) => void) | undefined,
+		flushSync = false
 	): (updater: Updater) => void {
 		return (updater) => {
 			handler?.(updater);
+			if (flushSync) {
+				syncScheduled = false;
+				syncOptions();
+			}
 			triggerUpdate?.();
 		};
 	}
@@ -92,8 +97,8 @@ export function createSvelteTable<TData extends RowData>(
 		table.setOptions((prev) => {
 			return mergeObjects(prev, options, {
 				state: mergeObjects(state, options.state || {}),
-				onColumnFiltersChange: wrapOnChange(options.onColumnFiltersChange),
-				onSortingChange: wrapOnChange(options.onSortingChange),
+				onColumnFiltersChange: wrapOnChange(options.onColumnFiltersChange, true),
+				onSortingChange: wrapOnChange(options.onSortingChange, true),
 				onPaginationChange: wrapOnChange(options.onPaginationChange),
 				onColumnVisibilityChange: wrapOnChange(options.onColumnVisibilityChange),
 				onRowSelectionChange: wrapOnChange(options.onRowSelectionChange),
@@ -111,13 +116,23 @@ export function createSvelteTable<TData extends RowData>(
 		});
 	}
 
+	let syncScheduled = false;
+	function scheduleSyncOptions() {
+		if (syncScheduled) return;
+		syncScheduled = true;
+		queueMicrotask(() => {
+			syncScheduled = false;
+			syncOptions();
+		});
+	}
+
 	// Create a proxy that calls subscribe() on property access
 	// This ensures any effect reading table properties will re-run on state changes
 	return new Proxy(table, {
 		get(target, prop, receiver) {
 			// Register as subscriber
 			subscribe();
-			syncOptions();
+			scheduleSyncOptions();
 
 			const value = Reflect.get(target, prop, receiver);
 			

--- a/src/lib/hooks/use-data-table.svelte.ts
+++ b/src/lib/hooks/use-data-table.svelte.ts
@@ -105,6 +105,46 @@ function createUrlWithSearch(params: URLSearchParams): string {
 	return `${currentUrl.pathname}${search ? `?${search}` : ''}${currentUrl.hash}`;
 }
 
+interface FilteredDataCache<TData> {
+	source: TData[];
+	filtersKey: string;
+	join: JoinOperator;
+	result: TData[];
+}
+
+function getClientFilteredData<TData>(
+	rawData: TData[],
+	columnFilters: ColumnFiltersState,
+	join: JoinOperator,
+	getColumnVariant: (columnId: string) => FilterVariant,
+	cache: FilteredDataCache<TData> | null
+): { data: TData[]; cache: FilteredDataCache<TData> | null } {
+	const advancedFilters = getValidFilters(
+		extractAdvancedFilters(columnFilters, getColumnVariant)
+	);
+
+	if (advancedFilters.length === 0) {
+		return { data: rawData, cache: null };
+	}
+
+	const filtersKey = JSON.stringify(advancedFilters);
+
+	if (
+		cache &&
+		cache.source === rawData &&
+		cache.filtersKey === filtersKey &&
+		cache.join === join
+	) {
+		return { data: cache.result, cache };
+	}
+
+	const result = filterRows(rawData, advancedFilters, join);
+	return {
+		data: result,
+		cache: { source: rawData, filtersKey, join, result }
+	};
+}
+
 export function useDataTable<TData>(
 	options: UseDataTableOptions<TData>
 ): UseDataTableReturn<TData> {
@@ -405,6 +445,7 @@ export function useDataTable<TData>(
 	});
 
 	const useClientAdvancedFiltering = enableAdvancedFilter && !manualFiltering;
+	let filteredDataCache: FilteredDataCache<TData> | null = null;
 
 	const table = createSvelteTable<TData>({
 		get data() {
@@ -414,15 +455,15 @@ export function useDataTable<TData>(
 				return rawData;
 			}
 
-			const advancedFilters = getValidFilters(
-				extractAdvancedFilters(columnFilters, getColumnVariant)
+			const next = getClientFilteredData(
+				rawData,
+				columnFilters,
+				joinOperator,
+				getColumnVariant,
+				filteredDataCache
 			);
-
-			if (advancedFilters.length === 0) {
-				return rawData;
-			}
-
-			return filterRows(rawData, advancedFilters, joinOperator);
+			filteredDataCache = next.cache;
+			return next.data;
 		},
 		columns,
 		...(getRowId ? { getRowId } : {}),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Changing status (or other select filters) in **Advanced Table** mode could freeze/crash the tab due to a reactive loop.

## Root cause

1. `filterRows()` returned a **new array reference** on every table property access → TanStack kept re-processing data.
2. `DataTableFilterList` synced `filterItems` on every `columnFilters` reference change → re-mounted Select components → fired `onValueChange` again.
3. A bidirectional `$effect` synced `joinOperator` with table meta on every read.

## Fix

- Memoize client-filtered data in `useDataTable` (stable reference when filters/data unchanged).
- Deep-compare filter snapshots before updating `filterItems`.
- Derive `joinOperator` from table meta (no sync effect).
- Batch `syncOptions` per microtask; flush immediately on filter/sort changes.

## Test

Data Table Demo → Advanced Table → add Status filter → pick a value (list or menu UI).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-557a98a9-1501-4ea3-a248-6a0c4b6f7149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-557a98a9-1501-4ea3-a248-6a0c4b6f7149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

