### PR TITLE
chore(demo): remove Stretch columns toggle

### DIFF
--- a/src/routes/grid-demo.svelte
+++ b/src/routes/grid-demo.svelte
@@ -272,8 +272,6 @@
 		enableColumnSelection: true
 	});
 
-	let stretchColumnsEnabled = $state(false);
-
 	const displayedRowCount = $derived(isLoading ? 0 : table.getRowModel().rows.length);
 
 	const rowCountLabel = $derived.by(() => {
@@ -394,15 +392,6 @@
 			<DataGridSortMenu {table} {dir} />
 			<DataGridRowHeightMenu {table} />
 			<DataGridViewMenu {table} {dir} />
-			<Button
-				variant={stretchColumnsEnabled ? 'default' : 'outline'}
-				size="sm"
-				onclick={() => {
-					stretchColumnsEnabled = !stretchColumnsEnabled;
-				}}
-			>
-				Stretch
-			</Button>
 		</div>
 	</div>
 
@@ -419,7 +408,6 @@
 			{table}
 			{height}
 			{dir}
-			stretchColumns={stretchColumnsEnabled}
 		/>
 		<DataGridActionBar
 			{table}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the **Stretch** toolbar button from the data grid demo.

**What Stretch did:** When enabled, `stretchColumns` sets `flex-grow: 1` on data columns so they expand to fill the grid width (tablecn-style). The demo toggle is removed; the grid still accepts `stretchColumns={true}` if needed in your own app.

**Demo:** Grid demo toolbar no longer shows Stretch; columns use default fixed sizing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-557a98a9-1501-4ea3-a248-6a0c4b6f7149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-557a98a9-1501-4ea3-a248-6a0c4b6f7149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

